### PR TITLE
Add support for looking up instances by name; add more tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ For all options, run ```ec2-snapper create --help```.
 
 ```
 Example:
-ec2-snapper create --region us-west-2 --instance=i-c724be30 --name=MyEc2Instance --dry-run --no-reboot
+ec2-snapper create --region=us-west-2 --instance-id=i-c724be30 --ami-name=MyEc2Instance --dry-run --no-reboot
 ```
-You must specify the AWS region (e.g. `us-west-2`) and the ID of an EC2 instance in that region (e.g. `i-c724be30`) to be snapshotted, and give it a name such as "MyWebsite.com".  A current timestamp will automatically be appended to the name.
+You must specify the AWS region (e.g. `--region=us-west-2`) and either the ID (e.g. `--instance-id=i-c724be30`) or the name as set in an EC2 tag called "Name" (e.g. `--instance-name=my-instance`) of an EC2 instance in that region to be snapshotted. You also specify what to name the AMI, such as "MyWebsite.com", using the `--ami-name` parameter.  A current timestamp will automatically be appended to the AMI name.
 
-For example, `./ec2-snapper create --instance i-c724be30 --name "MyWebsite.com"` resulted in an AMI named "MyWebsite.com - 2015-06-08 at 08_26_51 (UTC)".
+For example, `./ec2-snapper create --instance-id=i-c724be30 --ami-name="MyWebsite.com"` resulted in an AMI named "MyWebsite.com - 2015-06-08 at 08_26_51 (UTC)".
 
 Adding `--dry-run` will simulate the command without actually taking a snapshot.
 
@@ -109,9 +109,9 @@ For all options, run ```ec2-snapper delete --help```.
 
 ```
 Example:
-ec2-snapper delete --region us-west-2 --instance=i-c724b30 --older-than=30d --dry-run
+ec2-snapper delete --region=us-west-2 --instance-id=i-c724b30 --older-than=30d --dry-run
 ```
-You must specify the AWS region (e.g. `us-west-2`) and the ID of an EC2 instance in that region (e.g. `i-c724be30`) originally used to create the AMIs you wish to delete, even if that EC2 instance has since been stopped or terminated.
+You must specify the AWS region (e.g. `--region=us-west-2`) and either the ID (e.g. `--instance-id=i-c724be30`) or the name as set in an EC2 tag called "Name" (e.g. `--instance-name=my-instance`) of an EC2 instance in that region that was originally used to create the AMIs you wish to delete (even if that EC2 instance has since been stopped or terminated).
 
 `--older-than` accepts time values like `30d`, `5h` or `15m` for 30 days, 5 hours, or 15 minutes, respectively.  For example, `--older-than=30d` tells ec2-snapper to delete any AMI for the given EC2 instance that is older than 30 days.
 
@@ -122,7 +122,21 @@ You must specify the AWS region (e.g. `us-west-2`) and the ID of an EC2 instance
 ## Contributors
 This was my first golang program, so I'm sure the code can benefit from various optimizations.  Pull requests and bug reports are always welcome.
 
-## Tests
+### Running from source
+The easiest way to run ec2-snapper from source is with the following command:
+
+```bash
+go run main.go *_command.go
+```
+
+This is necessary because all the code is in the `main` package, so you have to tell Go explicitly what to build and
+run. For example, to run the `create` command, you could do:
+
+```bash
+go run main.go *_command.go create --region=us-west-2 --instance-id=i-c1234567 --ami-name=MyBackup
+```
+
+### Tests
 This repo contains two types of tests:
 
 1. Unit tests: fast, isolated tests of individual functions. They use the name format `unit_xxx_test.go`.

--- a/create_command.go
+++ b/create_command.go
@@ -10,21 +10,24 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mitchellh/cli"
 	"errors"
+	"fmt"
 )
 
 type CreateCommand struct {
-	Ui 		cli.Ui
-	AwsRegion 	string
-	InstanceId 	string
-	Name 		string
-	DryRun		bool
-	NoReboot	bool
+	Ui           cli.Ui
+	AwsRegion    string
+	InstanceId   string
+	InstanceName string
+	AmiName      string
+	DryRun       bool
+	NoReboot     bool
 }
 
 // descriptions for args
 var createDscrAwsRegion = "The AWS region to use (e.g. us-west-2)"
-var createDscrInstanceId = "The instance from which to create the AMI"
-var createDscrName = "The name of the AMI; the current timestamp will be automatically appended"
+var createDscrInstanceId = "The id of the instance from which to create the AMI"
+var createDscrInstanceName = "The name (from tags) of the instance from which to create the AMI"
+var createDscrAmiName = "The name of the AMI; the current timestamp will be automatically appended"
 var createDscrDryRun = "Execute a simulated run"
 var createDscrNoReboot = "If true, do not reboot the instance before creating the AMI. It is preferable to reboot the instance to guarantee a consistent filesystem when taking the snapshot, but the likelihood of an inconsistent snapshot is very low."
 
@@ -34,9 +37,10 @@ func (c *CreateCommand) Help() string {
 Create an AMI of the given EC2 instance.
 
 Available args are:
---region      ` + createDscrAwsRegion + `
---instance      ` + createDscrInstanceId + `
---name          ` + createDscrName + `
+--region      	` + createDscrAwsRegion + `
+--instance-id   ` + createDscrInstanceId + `
+--instance-name ` + createDscrInstanceName + `
+--ami-name      ` + createDscrAmiName + `
 --dry-run       ` + createDscrDryRun + `
 --no-reboot     ` + createDscrNoReboot
 }
@@ -52,8 +56,9 @@ func (c *CreateCommand) Run(args []string) int {
 	cmdFlags.Usage = func() { c.Ui.Output(c.Help()) }
 
 	cmdFlags.StringVar(&c.AwsRegion, "region", "", createDscrAwsRegion)
-	cmdFlags.StringVar(&c.InstanceId, "instance", "", createDscrInstanceId)
-	cmdFlags.StringVar(&c.Name, "name", "", createDscrName)
+	cmdFlags.StringVar(&c.InstanceId, "instance-id", "", createDscrInstanceId)
+	cmdFlags.StringVar(&c.InstanceName, "instance-name", "", createDscrInstanceName)
+	cmdFlags.StringVar(&c.AmiName, "ami-name", "", createDscrAmiName)
 	cmdFlags.BoolVar(&c.DryRun, "dry-run", false, createDscrDryRun)
 	cmdFlags.BoolVar(&c.NoReboot, "no-reboot", true, createDscrNoReboot)
 
@@ -72,29 +77,28 @@ func (c *CreateCommand) Run(args []string) int {
 func create(c CreateCommand) (string, error) {
 	snapshotId := ""
 
-	// Check for required command-line args
-	if c.AwsRegion == "" {
-		return snapshotId, errors.New("ERROR: The argument '--region' is required.")
-	}
-
-	if c.InstanceId == "" {
-		return snapshotId, errors.New("ERROR: The argument '--instance' is required.")
-	}
-
-	if c.Name == "" {
-		return snapshotId, errors.New("ERROR: The argument '--name' is required.")
+	if err := validateCreateArgs(c); err != nil {
+		return snapshotId, err
 	}
 
 	// Create an EC2 service object; AWS region is picked up from the "AWS_REGION" env var.
 	session := session.New(&aws.Config{Region: &c.AwsRegion})
 	svc := ec2.New(session)
 
+	if c.InstanceId == "" {
+		instanceId, err := getInstanceIdByName(c.InstanceName, svc, c.Ui)
+		if err != nil {
+			return snapshotId, err
+		}
+		c.InstanceId = instanceId
+	}
+
 	// Generate a nicely formatted timestamp for right now
 	const dateLayoutForAmiName = "2006-01-02 at 15_04_05 (MST)"
 	t := time.Now()
 
 	// Create the AMI Snapshot
-	name := c.Name + " - " + t.Format(dateLayoutForAmiName)
+	name := c.AmiName + " - " + t.Format(dateLayoutForAmiName)
 
 	c.Ui.Output("==> Creating AMI for " + c.InstanceId + "...")
 
@@ -120,7 +124,7 @@ func create(c CreateCommand) (string, error) {
 		Resources: []*string{&snapshotId},
 		Tags: []*ec2.Tag{
 			&ec2.Tag{ Key: aws.String("ec2-snapper-instance-id"), Value: &c.InstanceId },
-			&ec2.Tag{ Key: aws.String("Name"), Value: &c.Name },
+			&ec2.Tag{ Key: aws.String("Name"), Value: &c.AmiName },
 		},
 	})
 
@@ -154,4 +158,49 @@ func create(c CreateCommand) (string, error) {
 	// Announce success
 	c.Ui.Info("==> Success! Created " + snapshotId + " named \"" + name + "\"")
 	return snapshotId, nil
+}
+
+func validateCreateArgs(c CreateCommand) error {
+	if c.AwsRegion == "" {
+		return errors.New("ERROR: The argument '--region' is required.")
+	}
+
+	if (c.InstanceId == "" && c.InstanceName == "") || (c.InstanceId != "" && c.InstanceName != "") {
+		return errors.New("ERROR: You must specify exactly one of '--instance-id' or '--instance-name'.")
+	}
+
+	if c.AmiName == "" {
+		return errors.New("ERROR: The argument '--name' is required.")
+	}
+
+	return nil
+}
+
+func getInstanceIdByName(instanceName string, svc *ec2.EC2, ui cli.Ui) (string, error) {
+	ui.Output(fmt.Sprintf("Looking up id for instance named %s", instanceName))
+
+	nameTagFilter := ec2.Filter{
+		Name: aws.String("tag:Name"),
+		Values: []*string{aws.String(instanceName)},
+	}
+
+	result, err := svc.DescribeInstances(&ec2.DescribeInstancesInput{Filters: []*ec2.Filter{&nameTagFilter}})
+	if err != nil {
+		return "", err
+	}
+
+	if len(result.Reservations) != 1 {
+		return "", errors.New(fmt.Sprintf("Expected to find one result for instance name %s, but found %d", instanceName, len(result.Reservations)))
+	}
+
+	reservation := result.Reservations[0]
+
+	if len(reservation.Instances) != 1 {
+		return "", errors.New(fmt.Sprintf("Expected to find one instance with instance name %s, but found %d", instanceName, len(reservation.Instances)))
+	}
+
+	instance := reservation.Instances[0]
+	ui.Output(fmt.Sprintf("Found id %s for instance named %s", *instance.InstanceId, instanceName))
+
+	return *instance.InstanceId, nil
 }

--- a/integration_create_delete_test.go
+++ b/integration_create_delete_test.go
@@ -22,11 +22,15 @@ const USER_DATA_TEMPLATE =
 set -e
 echo '%s' > "%s"
 `
+var ui = &cli.BasicUi{
+	Reader:      os.Stdin,
+	Writer:      os.Stdout,
+	ErrorWriter: os.Stderr,
+}
+
 
 // An integration test that runs an EC2 instance, uses create_command to take a snapshot of it, and then delete_command
-// to delete that snapshot. Since testing these functions requires a lot of setup in an AWS account, it's faster and
-// easier to do a single integration test rather than a number of smaller unit tests that each do a lot of setup and
-// teardown.
+// to delete that snapshot.
 func TestCreateAndDelete(t *testing.T) {
 	t.Parallel()
 
@@ -35,30 +39,146 @@ func TestCreateAndDelete(t *testing.T) {
 	session := session.New(&aws.Config{Region: aws.String(AWS_REGION_FOR_TESTING)})
 	svc := ec2.New(session)
 
-	instance, uniqueId := launchInstance(svc, logger, t)
+	instance, instanceName := launchInstance(svc, logger, t)
 	defer terminateInstance(instance, svc, logger, t)
 	waitForInstanceToStart(instance, svc, logger, t)
 
-	ui := &cli.BasicUi{
-		Reader:      os.Stdin,
-		Writer:      os.Stdout,
-		ErrorWriter: os.Stderr,
-	}
-
-	snapshotId := takeSnapshot(instance, uniqueId, svc, ui, logger, t)
+	snapshotId := takeSnapshot(instanceName, ui, logger, t)
 	waitForSnapshotToBeAvailable(snapshotId, svc, logger, t)
 	verifySnapshotWorks(snapshotId, svc, logger, t)
 
-	deleteSnapshotForInstance(instance, ui, logger, t)
+	deleteSnapshotForInstance(instanceName, "0h", 0, ui, logger, t)
 	waitForSnapshotToBeDeleted(snapshotId, svc, logger, t)
 	verifySnapshotIsDeleted(snapshotId, svc, logger, t)
 }
 
-func launchInstance(svc *ec2.EC2, logger *log.Logger, t *testing.T) (*ec2.Instance, string) {
-	uniqueId := UniqueId()
-	userData := fmt.Sprint(USER_DATA_TEMPLATE, uniqueId, TEST_FILE_PATH)
+// An integration test that runs an EC2 instance, uses create_command to take a snapshot of it, and then calls the
+// delete_command to delete that snapshot, but setting the older than parmaeter in a way that should prevent any actual
+// deletion.
+func TestDeleteRespectsOlderThan(t *testing.T) {
+	t.Parallel()
 
-	logger.Printf("Launching EC2 instance in region %s. Its User Data will create a file %s with contents %s.", AWS_REGION_FOR_TESTING, TEST_FILE_PATH, uniqueId)
+	logger := log.New(os.Stdout, "TestDeleteRespectsOlderThan ", log.LstdFlags)
+
+	session := session.New(&aws.Config{Region: aws.String(AWS_REGION_FOR_TESTING)})
+	svc := ec2.New(session)
+
+	instance, instanceName := launchInstance(svc, logger, t)
+	defer terminateInstance(instance, svc, logger, t)
+	waitForInstanceToStart(instance, svc, logger, t)
+
+	snapshotId := takeSnapshot(instanceName, ui, logger, t)
+	waitForSnapshotToBeAvailable(snapshotId, svc, logger, t)
+	verifySnapshotWorks(snapshotId, svc, logger, t)
+
+	// Set olderThan to "10h" to ensure image does not get deleted
+	deleteSnapshotForInstance(instanceName, "10h", 0, ui, logger, t)
+	waitForSnapshotToBeDeleted(snapshotId, svc, logger, t)
+	// Check that the snapshot still exists
+	verifySnapshotWorks(snapshotId, svc, logger, t)
+}
+
+// An integration test that runs an EC2 instance, uses create_command to take a snapshot of it, and then calls the
+// delete_command to delete that snapshot, but setting the at least parameter in a way that should prevent any actual
+// deletion.
+func TestDeleteRespectsAtLeast(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New(os.Stdout, "TestDeleteRespectsAtLeast ", log.LstdFlags)
+
+	session := session.New(&aws.Config{Region: aws.String(AWS_REGION_FOR_TESTING)})
+	svc := ec2.New(session)
+
+	instance, instanceName := launchInstance(svc, logger, t)
+	defer terminateInstance(instance, svc, logger, t)
+	waitForInstanceToStart(instance, svc, logger, t)
+
+	snapshotId := takeSnapshot(instanceName, ui, logger, t)
+	waitForSnapshotToBeAvailable(snapshotId, svc, logger, t)
+	verifySnapshotWorks(snapshotId, svc, logger, t)
+
+	// Set atLeast to 1 to ensure image does not get deleted
+	deleteSnapshotForInstance(instanceName, "0h", 1, ui, logger, t)
+	waitForSnapshotToBeDeleted(snapshotId, svc, logger, t)
+	// Check that the snapshot still exists
+	verifySnapshotWorks(snapshotId, svc, logger, t)
+}
+
+func TestCreateWithInvalidInstanceName(t *testing.T) {
+	t.Parallel()
+
+	cmd := CreateCommand{
+		Ui: ui,
+		AwsRegion: AWS_REGION_FOR_TESTING,
+		InstanceName: "not-a-valid-instance-name",
+		AmiName: "this-ami-should-not-be-created",
+	}
+
+	_, err := create(cmd)
+
+	if err == nil {
+		t.Fatalf("Expected an error when creating a snapshot of an instance name that doesn't exist, but instead got nil")
+	}
+}
+
+func TestCreateWithInvalidInstanceId(t *testing.T) {
+	t.Parallel()
+
+	cmd := CreateCommand{
+		Ui: ui,
+		AwsRegion: AWS_REGION_FOR_TESTING,
+		InstanceId: "not-a-valid-instance-id",
+		AmiName: "this-ami-should-not-be-created",
+	}
+
+	_, err := create(cmd)
+
+	if err == nil {
+		t.Fatalf("Expected an error when creating a snapshot of an instance id that doesn't exist, but instead got nil")
+	}
+}
+
+func TestDeleteWithInvalidInstanceName(t *testing.T) {
+	t.Parallel()
+
+	cmd := DeleteCommand{
+		Ui: ui,
+		AwsRegion: AWS_REGION_FOR_TESTING,
+		InstanceName: "not-a-valid-instance-name",
+		OlderThan: "0h",
+		RequireAtLeast: 0,
+	}
+
+	err := deleteSnapshots(cmd)
+
+	if err == nil {
+		t.Fatalf("Expected an error when deleting a snapshot of an instance name that doesn't exist, but instead got nil")
+	}
+}
+
+func TestDeleteWithInvalidInstanceId(t *testing.T) {
+	t.Parallel()
+
+	cmd := DeleteCommand{
+		Ui: ui,
+		AwsRegion: AWS_REGION_FOR_TESTING,
+		InstanceId: "not-a-valid-instance-id",
+		OlderThan: "0h",
+		RequireAtLeast: 0,
+	}
+
+	err := deleteSnapshots(cmd)
+
+	if err == nil {
+		t.Fatalf("Expected an error when deleting a snapshot of an instance id that doesn't exist, but instead got nil")
+	}
+}
+
+func launchInstance(svc *ec2.EC2, logger *log.Logger, t *testing.T) (*ec2.Instance, string) {
+	instanceName := fmt.Sprintf("ec2-snapper-unit-test-%s", UniqueId())
+	userData := fmt.Sprint(USER_DATA_TEMPLATE, instanceName, TEST_FILE_PATH)
+
+	logger.Printf("Launching EC2 instance in region %s. Its User Data will create a file %s with contents %s.", AWS_REGION_FOR_TESTING, TEST_FILE_PATH, instanceName)
 
 	runResult, err := svc.RunInstances(&ec2.RunInstancesInput{
 		ImageId:      aws.String(AMAZON_LINUX_AMI_ID),
@@ -79,12 +199,12 @@ func launchInstance(svc *ec2.EC2, logger *log.Logger, t *testing.T) (*ec2.Instan
 	instance := runResult.Instances[0]
 	logger.Printf("Launched instance %s", *instance.InstanceId)
 
-	tagInstance(instance, uniqueId, svc, logger, t)
+	tagInstance(instance, instanceName, svc, logger, t)
 
-	return instance, uniqueId
+	return instance, instanceName
 }
 
-func tagInstance(instance *ec2.Instance, uniqueId string, svc *ec2.EC2, logger *log.Logger, t *testing.T) {
+func tagInstance(instance *ec2.Instance, instanceName string, svc *ec2.EC2, logger *log.Logger, t *testing.T) {
 	logger.Printf("Adding tags to instance %s", *instance.InstanceId)
 
 	_ , err := svc.CreateTags(&ec2.CreateTagsInput{
@@ -92,7 +212,7 @@ func tagInstance(instance *ec2.Instance, uniqueId string, svc *ec2.EC2, logger *
 		Tags: []*ec2.Tag{
 			{
 				Key:   aws.String("Name"),
-				Value: aws.String(fmt.Sprintf("ec2-snapper-unit-test-%s", uniqueId)),
+				Value: aws.String(instanceName),
 			},
 		},
 	})
@@ -116,16 +236,14 @@ func terminateInstance(instance *ec2.Instance, svc *ec2.EC2, logger *log.Logger,
 	}
 }
 
-func takeSnapshot(instance *ec2.Instance, uniqueId string, svc *ec2.EC2, ui cli.Ui, logger *log.Logger, t *testing.T) string {
-	backupName := fmt.Sprintf("ec2-snapper-unit-test-create-%s", uniqueId)
-	log.Printf("Creating a snapshot with name %s.", backupName)
-
+func takeSnapshot(instanceName string, ui cli.Ui, logger *log.Logger, t *testing.T) string {
+	log.Printf("Creating a snapshot with name %s.", instanceName)
 
 	cmd := CreateCommand{
 		Ui: ui,
 		AwsRegion: AWS_REGION_FOR_TESTING,
-		InstanceId: *instance.InstanceId,
-		Name: backupName,
+		InstanceName: instanceName,
+		AmiName: instanceName,
 	}
 
 	snapshotId, err := create(cmd)
@@ -189,15 +307,15 @@ func waitForSnapshotToBeDeleted(snapshotId string, svc *ec2.EC2, logger *log.Log
 	time.Sleep(30 * time.Second)
 }
 
-func deleteSnapshotForInstance(instance *ec2.Instance, ui cli.Ui, logger *log.Logger, t *testing.T) {
-	logger.Printf("Deleting snapshot for instance %s", *instance.InstanceId)
+func deleteSnapshotForInstance(instanceName string, olderThan string, requireAtLeast int, ui cli.Ui, logger *log.Logger, t *testing.T) {
+	logger.Printf("Deleting snapshot for instance %s", instanceName)
 
 	deleteCmd := DeleteCommand{
 		Ui: ui,
 		AwsRegion: AWS_REGION_FOR_TESTING,
-		InstanceId: *instance.InstanceId,
-		OlderThan: "0h",
-		RequireAtLeast: 0,
+		InstanceName: instanceName,
+		OlderThan: olderThan,
+		RequireAtLeast: requireAtLeast,
 	}
 
 	if err := deleteSnapshots(deleteCmd); err != nil {

--- a/integration_create_delete_test.go
+++ b/integration_create_delete_test.go
@@ -210,9 +210,15 @@ func tagInstance(instance *ec2.Instance, instanceName string, svc *ec2.EC2, logg
 
 func waitForInstanceToStart(instance *ec2.Instance, svc *ec2.EC2, logger *log.Logger, t *testing.T) {
 	logger.Printf("Waiting for instance %s to start...", *instance.InstanceId)
+
 	if err := svc.WaitUntilInstanceRunning(&ec2.DescribeInstancesInput{InstanceIds: []*string{instance.InstanceId}}); err != nil {
 		t.Fatal(err)
 	}
+
+	// It seems that the WaitUntilInstanceRunning returns even though the instance is still in "initializing" state,
+	// which may cause problems for taking snapshots, so sleep 30 seconds just to be extra sure
+	time.Sleep(30 * time.Second)
+
 	logger.Printf("Instance %s is now running", *instance.InstanceId)
 }
 


### PR DESCRIPTION
This PR does the following:

1. Add support for creating or deleting a snapshot using a `--instance-name` parameter rather than `--instance-id`. This is essential for running ec2-snapper from an automated job, such as a backup CRON job, as the instance-id may change every time you redeploy your server.
2. I've added several more tests, including integration tests that ensure the `delete` command respects the `--require-at-least` and `--older-than` parameters.
3. I've updated the tests with lots more sleeps, as AWS is very optimistic when it tells you "yup, this new resource is ready!" I can see why Terraform has so many bugs in this area...
